### PR TITLE
Sonar integration

### DIFF
--- a/.github/workflows/central_code_quality_check.yml
+++ b/.github/workflows/central_code_quality_check.yml
@@ -1,3 +1,5 @@
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+# Contact @moabu
 name: Code quality check
 
 on:
@@ -7,14 +9,34 @@ on:
   pull_request:
     branches:
       - master
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      JVM_PROJECTS: JanssenProject/jans-auth-server|JanssenProject/jans-orm|JanssenProject/jans-config-api|JanssenProject/jans-client-api|JanssenProject/jans-scim|JanssenProject/jans-core|JanssenProject/jans-notify|JanssenProject/jans-fido2|JanssenProject/jans-eleven
-      NON_JVM_PROJECTS: JanssenProject/jans-setup|JanssenProject/jans-cli|JanssenProject/docker-jans-persistence-loader|JanssenProject/docker-jans-client-api|JanssenProject/jans-pycloudlib|JanssenProject/docker-jans-auth-server|JanssenProject/docker-jans-fido2|JanssenProject/docker-jans-scim|JanssenProject/docker-jans-config-api|JanssenProject/docker-jans-certmanager|JanssenProject/docker-jans-configuration-manager|JanssenProject/jans-cloud-native
-    
+      JVM_PROJECTS: |
+        JanssenProject/jans-auth-server
+        JanssenProject/jans-orm
+        JanssenProject/jans-config-api
+        JanssenProject/jans-client-api
+        JanssenProject/jans-scim
+        JanssenProject/jans-core
+        JanssenProject/jans-notify
+        JanssenProject/jans-fido2
+        JanssenProject/jans-eleven
+      NON_JVM_PROJECTS: |
+        JanssenProject/jans-setup
+        JanssenProject/jans-cli
+        JanssenProject/docker-jans-persistence-loader
+        JanssenProject/docker-jans-client-api
+        JanssenProject/jans-pycloudlib
+        JanssenProject/docker-jans-auth-server
+        JanssenProject/docker-jans-fido2
+        JanssenProject/docker-jans-scim
+        JanssenProject/docker-jans-config-api
+        JanssenProject/docker-jans-certmanager
+        JanssenProject/docker-jans-configuration-manager
+        JanssenProject/jans-cloud-native
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/central_sync_workflows.yml
+++ b/.github/workflows/central_sync_workflows.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DRY_RUN: false
+      PULL_REQUEST: true
       REPOSITORIES: |
         JanssenProject/docker-jans-auth-server
         JanssenProject/docker-jans-certmanager
@@ -41,6 +42,7 @@ jobs:
 
       WORKFLOW_FILES: |
         .github/workflows/commit-check.yml
+        .github/workflows/central_code_quality_check.yml
       COMMIT_MESSAGE: 'ci(workflows): sync workflows'
     steps:
       - name: Fetching Local Repository
@@ -58,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DRY_RUN: false
+      PULL_REQUEST: true
       REPOSITORIES: |
         JanssenProject/docker-jans-auth-server
         JanssenProject/docker-jans-certmanager

--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -47,6 +47,10 @@ jobs:
               echo "Run maven build for jans-eleven"
               mvn clean -fae -pl \!client,\!server jacoco:prepare-agent test jacoco:report
             ;;
+            "JanssenProject/jans-config-api")
+              echo "Run maven build for jans-config-api"
+              mvn clean -fae -DskipTests=true jacoco:prepare-agent install jacoco:report
+            ;;
             *) 
             echo "Run maven build for Java repository"
             mvn clean -fae jacoco:prepare-agent test install jacoco:report
@@ -91,6 +95,10 @@ jobs:
             "JanssenProject/jans-eleven")
               echo "Run Sonar analysis for jans-scim"
               mvn -B -pl \!client,\!server verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+            "JanssenProject/jans-config-api")
+              echo "Run Sonar analysis for jans-config-api"
+              mvn -B -DskipTests=true verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
             ;;
             *) 
             echo "Run maven build for Java repository"

--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -97,13 +97,20 @@ jobs:
             mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
             ;;
           esac
-      
+
+      - name: Convert repo org name to lowercase for non JVM projects
+        if: contains(env.NON_JVM_PROJECTS, github.repository)
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          echo "REPO_ORG=${REPO_OWNER,,}" >>${GITHUB_ENV}
+
       - name: SonarCloud Scan for non-JVM project
         if: contains(env.NON_JVM_PROJECTS, github.repository)
         uses: SonarSource/sonarcloud-github-action@master
         with:
           args: >
-            -Dsonar.organization=${{ github.repository_owner }}
+            -Dsonar.organization=${{ env.REPO_ORG }}
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/code_quality_check.yml
+++ b/.github/workflows/code_quality_check.yml
@@ -1,0 +1,110 @@
+name: Code quality check
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      JVM_PROJECTS: JanssenProject/jans-auth-server|JanssenProject/jans-orm|JanssenProject/jans-config-api|JanssenProject/jans-client-api|JanssenProject/jans-scim|JanssenProject/jans-core|JanssenProject/jans-notify|JanssenProject/jans-fido2|JanssenProject/jans-eleven
+      NON_JVM_PROJECTS: JanssenProject/jans-setup|JanssenProject/jans-cli|JanssenProject/docker-jans-persistence-loader|JanssenProject/docker-jans-client-api|JanssenProject/jans-pycloudlib|JanssenProject/docker-jans-auth-server|JanssenProject/docker-jans-fido2|JanssenProject/docker-jans-scim|JanssenProject/docker-jans-config-api|JanssenProject/docker-jans-certmanager|JanssenProject/docker-jans-configuration-manager|JanssenProject/jans-cloud-native
+    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      
+      - name: Set up JDK 11
+        if: contains(env.JVM_PROJECTS, github.repository)
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          
+      - name: Build with Maven
+        if: contains(env.JVM_PROJECTS, github.repository)
+        run: |
+          case "$GITHUB_REPOSITORY" in
+            "JanssenProject/jans-auth-server") 
+              echo "Run maven build for jans-auth-server "
+              mvn clean -fae -X -pl \!client,\!static,\!server,\!rp-spring-boot jacoco:prepare-agent test install jacoco:report
+            ;;
+            "JanssenProject/jans-client-api") 
+              echo "Run maven build for jans-client-api"
+              mvn clean -fae -pl \!server jacoco:prepare-agent test install jacoco:report
+            ;;
+            "JanssenProject/jans-scim") 
+              echo "Run maven build for jans-scim"
+              mvn clean -fae -pl \!client jacoco:prepare-agent test install jacoco:report
+            ;;
+            "JanssenProject/jans-eleven")
+              echo "Run maven build for jans-eleven"
+              mvn clean -fae -pl \!client,\!server jacoco:prepare-agent test jacoco:report
+            ;;
+            *) 
+            echo "Run maven build for Java repository"
+            mvn clean -fae jacoco:prepare-agent test install jacoco:report
+            ;;
+          esac
+
+      - name: Cache SonarCloud packages for JVM based project
+        if: contains(env.JVM_PROJECTS, github.repository)
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+          
+      - name: Cache Maven packages
+        if: contains(env.JVM_PROJECTS, github.repository)
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+          
+      - name: Build and analyze JVM based project
+        if: contains(env.JVM_PROJECTS, github.repository)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          case "$GITHUB_REPOSITORY" in
+            "JanssenProject/jans-auth-server") 
+              echo "Run Sonar analysis for jans-auth-server "
+              mvn -B -pl \!client,\!static,\!server,\!rp-spring-boot verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+            "JanssenProject/jans-client-api") 
+              echo "Run Sonar analysis for jans-client-api"
+              mvn -B -pl \!server verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+            "JanssenProject/jans-scim") 
+              echo "Run Sonar analysis for jans-scim"
+              mvn -B -pl \!client verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+            "JanssenProject/jans-eleven")
+              echo "Run Sonar analysis for jans-scim"
+              mvn -B -pl \!client,\!server verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+            *) 
+            echo "Run maven build for Java repository"
+            mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            ;;
+          esac
+      
+      - name: SonarCloud Scan for non-JVM project
+        if: contains(env.NON_JVM_PROJECTS, github.repository)
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.organization=${{ github.repository_owner }}
+            -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This pull request has Github action workflow that is generic and can be applied all current Jans repos. 
It enables static code analysis and code coverage on each repository.

#### Static code analysis:
It should start showing static code analysis data on SonarCloud once this workflow is deployed in respective repos.

#### Code coverage data:
Code coverage would be shown less than actual for some of the repositories due to exclusion of those tests that depend on Jans server being up and running. As we figure out how to either make Jans server run within a Github action (probably via Github Service containers) or make tests run against an externally hosted Jans server. Once this is in place we can enable all the tests and modules. SonarCloud will then start reporting complete code coverage percentage. This will also allow us to remove switch case logic in current script and reduce complexity further. 

