### PR TITLE
fix: always close file descriptors after parsing LDIF files

### DIFF
--- a/docker-jans-persistence-loader/scripts/ldap_setup.py
+++ b/docker-jans-persistence-loader/scripts/ldap_setup.py
@@ -86,9 +86,10 @@ class LDAPBackend:
 
                 render_ldif(src, dst, ctx)
 
-                parser = LDIFParser(open(dst, "rb"))
-                for dn, entry in parser.parse():
-                    self.add_entry(dn, entry)
+                with open(dst, "rb") as fd:
+                    parser = LDIFParser(fd)
+                    for dn, entry in parser.parse():
+                        self.add_entry(dn, entry)
 
     def add_entry(self, dn, attrs):
         max_wait_time = 300


### PR DESCRIPTION
When parsing LDIF files, scripts will ensure file descriptors are closed using `with` context. Related issue: https://github.com/JanssenProject/jans-cloud-native/issues/153